### PR TITLE
feat: support change model

### DIFF
--- a/code/config.example.yaml
+++ b/code/config.example.yaml
@@ -10,6 +10,11 @@ BOT_NAME: chatGpt
 # OpenAI key
 # Support load balancing can fill in multiple keys separated by commas.
 OPENAI_KEY: sk-xxx,sk-xxx,sk-xxx
+# openAI model ，default: gpt-3.5-turbo
+# ："gpt-4-0314", "gpt-4", "gpt-3.5-turbo-0301","gpt-3.5-turbo-16k", "gpt-3.5-turbo"，如果使用gpt-4，请确认自己是否有接口调用白名单
+OPENAI_MODEL: gpt-3.5-turbo
+# openAI Max tokens default:2000
+OPENAI_MAX_TOKENS: 2000
 # Server Configuration
 HTTP_PORT: 9000
 HTTPS_PORT: 9001

--- a/code/config.example.yaml
+++ b/code/config.example.yaml
@@ -11,7 +11,8 @@ BOT_NAME: chatGpt
 # Support load balancing can fill in multiple keys separated by commas.
 OPENAI_KEY: sk-xxx,sk-xxx,sk-xxx
 # openAI model ，default: gpt-3.5-turbo
-# ："gpt-4-0314", "gpt-4", "gpt-3.5-turbo-0301","gpt-3.5-turbo-16k", "gpt-3.5-turbo"，如果使用gpt-4，请确认自己是否有接口调用白名单
+# support： "gpt-4-0314", "gpt-4", "gpt-3.5-turbo-0301","gpt-3.5-turbo-16k", "gpt-3.5-turbo"
+# if you use gpt-4, please confirm whether you have an interface call whitelist
 OPENAI_MODEL: gpt-3.5-turbo
 # openAI Max tokens default:2000
 OPENAI_MAX_TOKENS: 2000

--- a/code/handlers/event_msg_action.go
+++ b/code/handlers/event_msg_action.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"lark-openai/services/openai"
 	"lark-openai/utils"
+	"time"
 )
 
 type MessageAction struct { /*消息*/
@@ -10,6 +11,15 @@ type MessageAction struct { /*消息*/
 
 func (*MessageAction) Execute(a *ActionInfo) bool {
 	msg := a.handler.sessionCache.GetMsg(*a.info.sessionId)
+	if !hasSystemRole(msg) {
+		msg = append(msg, openai.Messages{
+			Role: "system", Content: "You are ChatGPT, " +
+				"a large language model trained by OpenAI. " +
+				"Answer in user's language as concisely as" +
+				" possible. Knowledge cutoff: 20230601 " +
+				"Current date" + time.Now().Format("20060102"),
+		})
+	}
 	msg = append(msg, openai.Messages{
 		Role: "user", Content: a.info.qParsed,
 	})
@@ -37,4 +47,13 @@ func (*MessageAction) Execute(a *ActionInfo) bool {
 		return false
 	}
 	return true
+}
+
+func hasSystemRole(msg []openai.Messages) bool {
+	for _, m := range msg {
+		if m.Role == "system" {
+			return true
+		}
+	}
+	return false
 }

--- a/code/initialization/config.go
+++ b/code/initialization/config.go
@@ -30,6 +30,8 @@ type Config struct {
 	AzureDeploymentName        string
 	AzureResourceName          string
 	AzureOpenaiToken           string
+	OpenaiModel                string
+	OpenaiMaxTokens            int
 }
 
 func LoadConfig(cfg string) *Config {
@@ -50,6 +52,8 @@ func LoadConfig(cfg string) *Config {
 		FeishuAppVerificationToken: getViperStringValue("APP_VERIFICATION_TOKEN", ""),
 		FeishuBotName:              getViperStringValue("BOT_NAME", ""),
 		OpenaiApiKeys:              getViperStringArray("OPENAI_KEY", nil),
+		OpenaiModel:                getViperStringValue("OPENAI_MODEL", "gpt-3.5-turbo"),
+		OpenaiMaxTokens:            getViperIntValue("OPENAI_MAX_TOKENS", 2000),
 		HttpPort:                   getViperIntValue("HTTP_PORT", 9000),
 		HttpsPort:                  getViperIntValue("HTTPS_PORT", 9001),
 		UseHttps:                   getViperBoolValue("USE_HTTPS", false),

--- a/code/role_list.yaml
+++ b/code/role_list.yaml
@@ -1,7 +1,12 @@
 # 可在此处提交你认为不错的角色预设，注意保持格式一致。
 # PR 时的 tag 暂时集中在 [ "日常办公",  "生活助手" ,"代码专家", "文案撰写"]
 # 更多点子可参考我另一个参与的项目: https://open-gpt.app/
-
+- title: ChatGPT
+  content: "You are ChatGPT, a large language model trained by OpenAI. Answer in user's language as concisely as possible. Knowledge cutoff: 20230601 Current date:20230628"
+  example:
+  author: river
+  tags:
+    - 日常办公
 - title: 周报生成
   content: 请帮我把以下的工作内容填充为一篇完整的周报，用 markdown 格式以分点叙述的形式输出：
   example: 重新优化设计稿，和前端再次沟通 UI 细节，确保落地

--- a/code/role_list_en.yaml
+++ b/code/role_list_en.yaml
@@ -1,7 +1,15 @@
-# 可在此处提交你认为不错的角色预设，注意保持格式一致。
-# PR 时的 tag 暂时集中在 [ "日常办公",  "生活助手" ,"代码专家", "文案撰写"]
-# 更多点子可参考我另一个参与的项目: https://open-gpt.app/
+# You can submit role presets that you think are good here, and pay attention to keeping the format consistent.
+#The tag of# PR temporarily focuses on ["daily office", "life assistant", "code expert" and "copywriting"]
 
+# For more ideas, please refer to another project I participated in: https://open-gpt.app/
+
+- title: ChatGPT
+  content: "You are ChatGPT, a large language model trained by OpenAI. Answer in user's language as concisely as possible. Knowledge cutoff: 20230601 Current date:20230628"
+  example:
+  author: river
+  tags:
+    - Daily Office
+    -
 - title: Weekly Report Generation
   content: Please help me fill in the following work details as a complete weekly report, using markdown format and bullet points
   example: Re-optimized design drafts and communicated UI details with the frontend team again to ensure successful implementation.

--- a/code/services/openai/common.go
+++ b/code/services/openai/common.go
@@ -41,6 +41,8 @@ type ChatGPT struct {
 	HttpProxy   string
 	Platform    PlatForm
 	AzureConfig AzureConfig
+	Model       string
+	MaxTokens   int
 }
 type requestBodyType int
 
@@ -212,6 +214,8 @@ func NewChatGPT(config initialization.Config) *ChatGPT {
 		ApiUrl:    config.OpenaiApiUrl,
 		HttpProxy: config.HttpProxy,
 		Platform:  platform,
+		Model:     config.OpenaiModel,
+		MaxTokens: config.OpenaiMaxTokens,
 		AzureConfig: AzureConfig{
 			BaseURL:        AzureApiUrlV1,
 			ResourceName:   config.AzureResourceName,

--- a/code/services/openai/gpt3.go
+++ b/code/services/openai/gpt3.go
@@ -75,9 +75,9 @@ func (msg *Messages) CalculateTokenLength() int {
 func (gpt *ChatGPT) Completions(msg []Messages, aiMode AIMode) (resp Messages,
 	err error) {
 	requestBody := ChatGPTRequestBody{
-		Model:            engine,
+		Model:            gpt.Model,
 		Messages:         msg,
-		MaxTokens:        maxTokens,
+		MaxTokens:        gpt.MaxTokens,
 		Temperature:      aiMode,
 		TopP:             1,
 		FrequencyPenalty: 0,


### PR DESCRIPTION
# feature
1. support custom openai model
```
# openAI model :"gpt-4-0314", "gpt-4", "gpt-3.5-turbo-0301","gpt-3.5-turbo-16k", "gpt-3.5-turbo"
# default: gpt-3.5-turbo
# If you use gpt-4, please confirm whether you have an interface call whitelist
OPENAI_MODEL: gpt-3.5-turbo

# openAI Max tokens default:2000
OPENAI_MAX_TOKENS: 2000
```

2.  simulate the effect of Chat GPT web
```
"You are ChatGPT, a large language model trained by OpenAI. Answer in user's language as concisely as possible. Knowledge cutoff: {knowledge_cutoff} Current date: {current_date}"

```